### PR TITLE
Bump Jinja from 2.9.6 to 2.10.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,6 @@ boto==2.48.0
 click==6.7
 Flask==1.0
 itsdangerous==0.24
-Jinja2==2.9.6
+Jinja2==2.10.1
 MarkupSafe==1.0
 Werkzeug==0.15.3


### PR DESCRIPTION
*Description of changes:*
Bumping Jinja version to 2.10.1 due to security vulnerabilities with prior versions.
https://github.com/advisories/GHSA-462w-v97r-4m45

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
